### PR TITLE
add version.txt to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include MANIFEST.in
 include tox.ini
+include version.txt


### PR DESCRIPTION
- Adds version.txt to MANIFEST.in
- Tested build to confirm file then present in dist
- Tested pip install to confirm only missing component (assuming notmuch package is present for c library binding).

- version.txt is only required because it's read by setup.py to set file version etc. There are probably more modern ways to do this, but this was minimum change to create a working package.